### PR TITLE
Add auto-load for Gulp plugins

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,19 +1,7 @@
-var gulp          = require('gulp'),
-    gulpif        = require('gulp-if'),
-    concat        = require('gulp-concat'),
-    rimraf        = require('gulp-rimraf'),
-    templateCache = require('gulp-angular-templatecache'),
-    minifyHtml    = require('gulp-minify-html'),
-    es            = require('event-stream'),
-    sass          = require('gulp-sass'),
-    jshint        = require('gulp-jshint'),
-    rename        = require('gulp-rename'),
-    ngAnnotate    = require('gulp-ng-annotate'),
-    uglify        = require('gulp-uglify'),
-    minifyCSS     = require('gulp-minify-css'),
-    webserver     = require('gulp-webserver'),
-    testem        = require('gulp-testem'),
-    argv          = require('yargs').argv;
+var gulp    = require('gulp');
+var plugins = require('gulp-load-plugins')();
+var es      = require('event-stream');
+var argv    = require('yargs').argv;
 
 var paths = {
   appJavascript:    ['app/js/app.js', 'app/js/**/*.js'],
@@ -37,50 +25,50 @@ var paths = {
 
 gulp.task('scripts', function() {
   return gulp.src(paths.vendorJavascript.concat(paths.appJavascript, paths.appTemplates))
-    .pipe(gulpif(/html$/, buildTemplates()))
-    .pipe(concat('app.js'))
-    .pipe(gulpif(argv.production, ngAnnotate()))
-    .pipe(gulpif(argv.production, uglify()))
-    .pipe(gulpif(argv.production, gulp.dest(paths.distJavascript), gulp.dest(paths.tmpJavascript)));
+    .pipe(plugins.if(/html$/, buildTemplates()))
+    .pipe(plugins.concat('app.js'))
+    .pipe(plugins.if(argv.production, plugins.ngAnnotate()))
+    .pipe(plugins.if(argv.production, plugins.uglify()))
+    .pipe(plugins.if(argv.production, gulp.dest(paths.distJavascript), gulp.dest(paths.tmpJavascript)));
 });
 
 gulp.task('styles', function() {
   return gulp.src(paths.vendorCss.concat(paths.appMainSass))
-    .pipe(gulpif(/scss$/, sass()))
-    .pipe(concat('app.css'))
-    .pipe(gulpif(argv.production, minifyCSS()))
-    .pipe(gulpif(argv.production, gulp.dest(paths.distCss), gulp.dest(paths.tmpCss)));
+    .pipe(plugins.if(/scss$/, plugins.sass()))
+    .pipe(plugins.concat('app.css'))
+    .pipe(plugins.if(argv.production, plugins.minifyCss()))
+    .pipe(plugins.if(argv.production, gulp.dest(paths.distCss), gulp.dest(paths.tmpCss)));
 });
 
 gulp.task('images', function() {
   return gulp.src(paths.appImages)
-    .pipe(gulpif(argv.production, gulp.dest(paths.distImages), gulp.dest(paths.tmpImages)));
+    .pipe(plugins.if(argv.production, gulp.dest(paths.distImages), gulp.dest(paths.tmpImages)));
 });
 
 gulp.task('indexHtml', function() {
   return gulp.src(paths.indexHtml)
-    .pipe(gulpif(argv.production, gulp.dest(paths.distFolder), gulp.dest(paths.tmpFolder)));
+    .pipe(plugins.if(argv.production, gulp.dest(paths.distFolder), gulp.dest(paths.tmpFolder)));
 });
 
 gulp.task('lint', function() {
   return gulp.src(paths.appJavascript.concat(paths.specFolder))
-    .pipe(jshint())
-    .pipe(jshint.reporter('jshint-stylish'));
+    .pipe(plugins.jshint())
+    .pipe(plugins.jshint.reporter('plugins.jshint-stylish'));
 });
 
 gulp.task('testem', function() {
-  return gulp.src(['']) // We don't need files, that is managed on testem.json
-    .pipe(testem({
+  return gulp.src(['']) // We don't need files, that is managed on plugins.testem.json
+    .pipe(plugins.testem({
       configFile: 'testem.json'
     }));
 });
 
 gulp.task('clean', function() {
   return gulp.src([paths.tmpFolder, paths.distFolder], {read: false})
-    .pipe(rimraf());
+    .pipe(plugins.rimraf());
 });
 
-gulp.task('watch', ['webserver'], function() {
+gulp.task('watch', ['plugins.webserver'], function() {
   gulp.watch(paths.appJavascript, ['lint', 'scripts']);
   gulp.watch(paths.appTemplates, ['scripts']);
   gulp.watch(paths.vendorJavascript, ['scripts']);
@@ -90,9 +78,9 @@ gulp.task('watch', ['webserver'], function() {
   gulp.watch(paths.appStyles, ['styles']);
 });
 
-gulp.task('webserver', ['scripts', 'styles', 'images', 'indexHtml'], function() {
+gulp.task('plugins.webserver', ['scripts', 'styles', 'images', 'indexHtml'], function() {
   gulp.src(paths.tmpFolder)
-    .pipe(webserver({
+    .pipe(plugins.webserver({
       port: 5000,
       proxies: [
         {
@@ -106,12 +94,12 @@ gulp.task('default', ['watch']);
 
 function buildTemplates() {
   return es.pipeline(
-    minifyHtml({
+    plugins.minifyHtml({
       empty: true,
       spare: true,
       quotes: true
     }),
-    templateCache({
+    plugins.angularTemplatecache({
       module: 'app'
     })
   );

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "gulp-concat": "^2.3.4",
     "gulp-if": "^1.2.4",
     "gulp-jshint": "^1.8.5",
+    "gulp-load-plugins": "^0.7.0",
     "gulp-minify-css": "^0.3.8",
     "gulp-minify-html": "^0.1.4",
     "gulp-ng-annotate": "^0.3.0",


### PR DESCRIPTION
Make `gulpfile.js` use `gulp-load-plugins` to auto-load plugins. So, instead of manually requiring all of them you can use them directly under the namespace of `plugins`.

Very opinionated, of course. Since Gulp plugins are not explicitly imported anymore on the `gulpfile.js`, and are just defined under `package.json`.
